### PR TITLE
ci: adds a reusable workflow for tag

### DIFF
--- a/.github/docs/Bump_Version.md
+++ b/.github/docs/Bump_Version.md
@@ -16,6 +16,8 @@ This workflow automatically bumps the project version using semantic versioning,
 
 - `default_branch` (optional): Default branch name  
   - default: `main`
+- `working-directory` (optional): The working directory to run the job in
+  - default: `.`
 
 **Secrets:**
 

--- a/.github/docs/Tag.md
+++ b/.github/docs/Tag.md
@@ -16,6 +16,8 @@ This workflow extracts the current version from a Python package's `__init__.py`
 
 - `default_branch` (optional): Default branch name  
   - default: `main`
+- `working-directory` (optional): The working directory to run the job in
+  - default: `.`
 
 **Secrets:**
 

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -12,6 +12,11 @@ on:
         default: main
         required: false
         type: string
+      working-directory:
+        description: 'The working directory to run the job in'
+        required: false
+        type: string
+        default: '.'
     secrets:
       repo-token:
         required: true
@@ -22,9 +27,12 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       new_version: ${{ steps.output_version.outputs.new_version }}
+    defaults:
+      run:
+        working-directory: ./${{ inputs.working-directory }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
       with:
         ref: ${{ inputs.default_branch }}
         fetch-depth: 0

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -8,6 +8,11 @@ on:
         default: main
         required: false
         type: string
+      working-directory:
+        description: 'The working directory to run the job in'
+        required: false
+        type: string
+        default: '.'
     secrets:
       repo-token:
         required: true
@@ -16,6 +21,9 @@ jobs:
   tag:
     name: Create and Push Tag
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./${{ inputs.working-directory }}
     steps:
     - name: Checkout
       uses: actions/checkout@v3


### PR DESCRIPTION
- A release reusable workflow that bumps versions and creates a new Git tag.