### PR TITLE
ci: adds reusable workflows for updating badges

### DIFF
--- a/.github/docs/Update Badges.md
+++ b/.github/docs/Update Badges.md
@@ -23,7 +23,7 @@ This workflow updates status badges (Python version, docstring coverage, and tes
 
 **Secrets:**
 
-- `SERVICE_TOKEN` (required): Token with write permission to push changes
+- `repo-token` (required): Token with write permission to push changes
 
 **Outputs:** N/A
 
@@ -43,7 +43,7 @@ jobs:
       default-branch: main
       python-version: "3.10"
     secrets:
-      SERVICE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      repo-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 **Results:**

--- a/.github/workflows/util-update-badges.yml
+++ b/.github/workflows/util-update-badges.yml
@@ -14,12 +14,12 @@ on:
         required: false
         type: string
       working-directory:
-        description: Working directory for the CI tasks
+        description: 'Working directory for the CI tasks'
         required: false
         type: string
         default: '.'
     secrets:
-      SERVICE_TOKEN:
+      repo-token:
         required: true
 
 jobs:
@@ -30,11 +30,11 @@ jobs:
       run:
         working-directory: ./${{ inputs.working-directory }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         ref: ${{ inputs.default-branch }}
         fetch-depth: 0
-        token: ${{ secrets.SERVICE_TOKEN }}
+        token: ${{ secrets.repo-token }}
     - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:


### PR DESCRIPTION
Closes #9 
- A reusable workflow for updating badges in a README.