### PR TITLE
Add reusable Sphinx docs CI workflow

### DIFF
--- a/.github/docs/Docs_CI.md
+++ b/.github/docs/Docs_CI.md
@@ -1,0 +1,76 @@
+# Docs CI (Sphinx)
+
+**Name:** `Docs CI (Sphinx)`
+
+**Workflow File:** `docs-ci.yml`
+
+**Description:**
+
+This workflow builds Sphinx documentation for a Python project using `uv`. It installs project dependencies (including an optional `docs` extra), optionally runs `sphinx-apidoc` to generate API stubs, builds the HTML with `-W` (warnings as errors) by default, optionally runs `sphinx-build -b linkcheck` as a non-blocking check, and uploads the built site as a workflow artifact. Designed to be triggered via `workflow_call`.
+
+> **Scope:** This reusable is for **Sphinx**-based documentation (`docs/source/conf.py`, RST or MyST sources) as used by `aind-library-template` and existing production repos. It is not an MkDocs reusable workflow. The software-practices standard for scientific computing and SIPE specifies MkDocs + mkdocstrings for new documentation. Pick whichever matches your project.
+
+## Parameters
+
+**Inputs:**
+
+- `runner_label` (optional): Runner to use
+  - default: `ubuntu-latest`
+- `python-version` (optional): Python version to use
+  - default: `3.12`
+- `docs-extra` (optional): Optional `[project.optional-dependencies]` extra to install (e.g. `docs`). Leave empty to skip.
+  - default: `docs`
+- `docs-path` (optional): Path to the Sphinx source dir
+  - default: `docs`
+- `output-dir` (optional): Where to write built HTML
+  - default: `docs/_build/html`
+- `fail-on-warnings` (optional): Treat Sphinx warnings as errors (`-W`)
+  - default: `true`
+- `linkcheck` (optional): Run `sphinx-build -b linkcheck` (non-blocking)
+  - default: `false`
+- `run-apidoc` (optional): Run `sphinx-apidoc` before build
+  - default: `false`
+- `apidoc-args` (optional): Args passed to `sphinx-apidoc`
+  - default: `-o docs/api src`
+- `artifact-name` (optional): Name for the uploaded site artifact
+  - default: `site`
+
+**Secrets:** N/A
+
+**Outputs:** N/A (uploads a workflow artifact named per `artifact-name`)
+
+## Example
+
+**workflow.yml**
+```yml
+name: docs (CI)
+
+on:
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  docs:
+    uses: AllenNeuralDynamics/.github/.github/workflows/docs-ci.yml@main
+    with:
+      python-version: '3.12'
+      docs-extra: 'docs'
+      docs-path: 'docs/source'
+      output-dir: 'docs/build/html'
+      fail-on-warnings: true
+      linkcheck: false
+      run-apidoc: false
+      # apidoc-args: '-o docs/api src/your_package -f'
+```
+
+**Results:**
+
+- Sphinx builds the docs tree under `docs-path` into `output-dir`.
+- Warnings fail the build by default (opt out via `fail-on-warnings: false`).
+- Built HTML is uploaded as an artifact named per `artifact-name`, ready to be consumed by a Pages-deploy workflow or downloaded for review.
+
+**Prerequisites:**
+
+- `pyproject.toml` with Sphinx and any theme/extension deps, preferably under an optional `[project.optional-dependencies] docs = [...]` extra.
+- A `uv.lock` is recommended for reproducible installs but not required; the workflow uses `uv sync` (not `--locked`), which will create a lockfile if missing.

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -50,15 +50,15 @@ jobs:
     runs-on: ${{ inputs.runner_label }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ inputs.python-version }}
           enable-cache: true
@@ -89,7 +89,7 @@ jobs:
         run: uv run --frozen sphinx-build -b linkcheck "${{ inputs.docs-path }}" "${{ inputs.docs-path }}/_build/linkcheck" || true
 
       - name: Upload built site as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs.artifact-name }}
           path: ${{ inputs.output-dir }}

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -1,0 +1,95 @@
+name: Docs CI (Sphinx)
+
+on:
+  workflow_call:
+    inputs:
+      runner_label:
+        description: Runner to use
+        type: string
+        default: 'ubuntu-latest'
+      python-version:
+        description: Python version to use
+        type: string
+        default: '3.12'
+      docs-extra:
+        description: Optional pyproject `[project.optional-dependencies]` extra to install (e.g. `docs`). Leave empty to skip.
+        type: string
+        default: 'docs'
+      docs-path:
+        description: Path to the Sphinx source dir
+        type: string
+        default: 'docs'
+      output-dir:
+        description: Where to write built HTML
+        type: string
+        default: 'docs/_build/html'
+      fail-on-warnings:
+        description: Treat Sphinx warnings as errors (-W)
+        type: boolean
+        default: true
+      linkcheck:
+        description: Run `sphinx-build -b linkcheck` (non-blocking)
+        type: boolean
+        default: false
+      run-apidoc:
+        description: Run `sphinx-apidoc` before build
+        type: boolean
+        default: false
+      apidoc-args:
+        description: Args passed to `sphinx-apidoc`
+        type: string
+        default: '-o docs/api src'
+      artifact-name:
+        description: Name for the uploaded site artifact
+        type: string
+        default: 'site'
+
+jobs:
+  build-docs:
+    name: Build docs
+    runs-on: ${{ inputs.runner_label }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+          enable-cache: true
+
+      - name: Install project + docs deps
+        run: |
+          if [ -n "${{ inputs.docs-extra }}" ]; then
+            uv sync --extra "${{ inputs.docs-extra }}"
+          else
+            uv sync
+          fi
+
+      - name: Generate API stubs (optional)
+        if: inputs.run-apidoc == true
+        run: uv run --frozen sphinx-apidoc ${{ inputs.apidoc-args }}
+
+      - name: Ensure autosummary dirs exist
+        run: mkdir -p "${{ inputs.docs-path }}/generated" "${{ inputs.docs-path }}/_autosummary" || true
+
+      - name: Build HTML
+        run: |
+          FLAGS=""
+          if [ "${{ inputs.fail-on-warnings }}" = "true" ]; then FLAGS="-W"; fi
+          uv run --frozen sphinx-build $FLAGS -b html "${{ inputs.docs-path }}" "${{ inputs.output-dir }}"
+
+      - name: Linkcheck (non-blocking)
+        if: inputs.linkcheck == true
+        run: uv run --frozen sphinx-build -b linkcheck "${{ inputs.docs-path }}" "${{ inputs.docs-path }}/_build/linkcheck" || true
+
+      - name: Upload built site as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: ${{ inputs.output-dir }}


### PR DESCRIPTION
- Adds `.github/workflows/docs-ci.yml`, a reusable workflow that builds Sphinx documentation with `uv`, optionally runs `sphinx-apidoc` and `sphinx-build -b linkcheck`, and uploads the built site as an artifact.
- Adds `.github/docs/Docs_CI.md` in the same format as existing reusables (`CI.md`, `Bump_Version.md`).

### Motivation

This repo has reusables for tests, linting, typing, tagging, and publishing — but none for documentation builds. Repos that want to validate their docs build on PRs currently write per-repo workflows or copy-paste between projects. This fills that gap.

Defaults match common Sphinx layouts (`docs/` → `docs/_build/html`) and surface the most commonly tweaked knobs (extra, path, `-W`, apidoc, linkcheck) as workflow inputs.

### Design notes

- `uv sync` without `--locked` so repos without a `uv.lock` can adopt without a prerequisite PR; repos with a lockfile still get deterministic installs.
- Action versions pinned to the repo's existing floor: `actions/checkout@v4`, `actions/setup-python@v5`, `astral-sh/setup-uv@v5`, `actions/upload-artifact@v4`.
- Artifact-only output. No Pages deploy. A separate workflow downstream of this one can deploy so repos can gate deploy on non-docs checks.
- `runner_label` input matches the pattern used by `test.yml` / `lint.yml` / `type.yml`.

### Scope: Sphinx, not MkDocs

The [AIND software-practices standard](https://docs.allenneuraldynamics.org/en/latest/policies_practices/software_practices.html) specifies MkDocs + mkdocstrings for new documentation. In current practice, `aind-library-template` and a number of production repos use Sphinx (`docs/source/conf.py`, RST sources). This workflow can be used for projects that still use Sphinx, and is not a position on the MkDocs-vs-Sphinx question.

A MkDocs reusable can live alongside this one and be added as a follow-up; the two are independent and callers pick whichever matches their project.