### PR TITLE
Add reusable wheel smoke-test workflow

### DIFF
--- a/.github/docs/Wheel_Smoke.md
+++ b/.github/docs/Wheel_Smoke.md
@@ -1,0 +1,62 @@
+# Wheel Smoke Test
+
+**Name:** `Wheel Smoke Test`
+
+**Workflow File:** `wheel-smoke.yml`
+
+**Description:**
+
+This workflow builds the project wheel with `uv build --wheel`, installs it into an isolated virtual environment, and runs the project's test suite **against the installed wheel** (not against the source tree). It catches the class of packaging bugs — missing subpackages, missing `package_data`, incorrect src-layout configuration, missing type stubs — that source-tree-only tests silently pass. Designed to be triggered via `workflow_call` and paired with `test.yml`.
+
+**Created By:** AIND Scientific Computing
+
+## Parameters
+
+**Inputs:**
+
+- `runner_label` (optional): Runner to use
+  - default: `ubuntu-latest`
+- `python-version` (optional): Python version to build and smoke-test against
+  - default: `3.12`
+- `smoke-test-paths` (optional): Space-separated list of files or directories copied into the smoke-test sandbox alongside the built wheel. Typically `tests` so pytest has a suite to run against the installed wheel.
+  - default: `tests`
+
+**Secrets:** N/A
+
+**Outputs:** N/A
+
+## Example
+
+**workflow.yml**
+```yml
+name: Wheel Smoke
+
+on:
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    uses: AllenNeuralDynamics/.github/.github/workflows/wheel-smoke.yml@main
+    with:
+      python-version: '3.12'
+      smoke-test-paths: 'tests'
+```
+
+**Results:**
+
+- The wheel is built into `dist/`.
+- A throwaway sandbox is created under `${{ runner.temp }}/wheeltest/`; `smoke-test-paths` (e.g. `tests`) plus the wheel are copied in.
+- A fresh `uv venv` is created inside the sandbox, `pytest` and the wheel are installed, and pytest runs against the **installed** package — so the source tree cannot satisfy imports.
+- If the wheel is missing a subpackage, data file, or entry point, pytest imports fail and the job fails.
+
+**Why this is worth running:**
+
+Ordinary `pytest` run against the source tree passes even when the built wheel is broken, because pytest finds code via `src/` / sys.path rather than via the installed distribution. This workflow is the cheap way to catch:
+
+- Missing subpackages (forgot to list them in `[tool.setuptools.packages.find]` or `pyproject.toml [tool.hatch.build.targets.wheel]`).
+- Missing `package_data` / resource files.
+- Wrong src-layout (`src/foo/` not being picked up by the backend).
+- Missing py.typed or .pyi stubs.
+- Entry-point typos that only surface post-install.

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -25,15 +25,15 @@ jobs:
     runs-on: ${{ inputs.runner_label }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ inputs.python-version }}
           enable-cache: true

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -1,0 +1,67 @@
+name: Wheel Smoke Test
+
+on:
+  workflow_call:
+    inputs:
+      runner_label:
+        description: Runner to use
+        type: string
+        default: 'ubuntu-latest'
+      python-version:
+        description: Python version to build and smoke-test against
+        type: string
+        default: '3.12'
+      smoke-test-paths:
+        description: |
+          Space-separated list of files or directories copied into the smoke-test
+          sandbox alongside the built wheel. Typically `tests` so pytest has a
+          suite to run against the installed wheel.
+        type: string
+        default: 'tests'
+
+jobs:
+  smoke:
+    name: Build wheel and smoke-test
+    runs-on: ${{ inputs.runner_label }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+          enable-cache: true
+
+      - name: Install project
+        run: uv sync
+
+      - name: Build wheel
+        run: uv build --wheel
+
+      - name: Smoke-test built wheel
+        shell: bash
+        run: |
+          TEMP_DIR="${{ runner.temp }}/wheeltest"
+          mkdir -p "$TEMP_DIR"
+          for path in ${{ inputs.smoke-test-paths }}; do
+            cp -r "$path" "$TEMP_DIR/" || echo "Warning: '$path' not found"
+          done
+          cp dist/*.whl "$TEMP_DIR/"
+          cd "$TEMP_DIR"
+
+          uv venv .venv
+
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            PY=".venv/Scripts/python.exe"
+          else
+            PY=".venv/bin/python"
+          fi
+
+          uv pip install --python "$PY" pytest *.whl
+          "$PY" -m pytest -q


### PR DESCRIPTION
- Adds `.github/workflows/wheel-smoke.yml`, a reusable workflow that builds the project wheel and runs the test suite against the **installed** wheel in an isolated venv.
- Adds `.github/docs/Wheel_Smoke.md`.

### Motivation

`test.yml` runs pytest against the source tree, which silently passes for whole classes of packaging bugs:

- Subpackages not listed in the build-backend's package discovery (`[tool.setuptools.packages.find]`, `[tool.hatch.build.targets.wheel]`, etc.).
- Missing `package_data` / resource files.
- Wrong src-layout configuration — `src/foo/` fine locally via editable install, broken in the wheel.
- Missing `py.typed` or `.pyi` stubs.
- Entry-point typos that only surface post-install.

These manifest as "import works on main, install from PyPI is broken" bugs. The fix is to also run the test suite against the installed wheel. This workflow does that: 

- `uv build --wheel` 
- copy `tests/` + wheel into a scratch dir 
- fresh venv 
- `pip install pytest wheel` 
- `pytest`.

Independent of `test.yml`, so repos can opt in per-PR without restructuring their existing CI.

### Design notes

- `smoke-test-paths` is space-separated to allow repos with fixtures outside `tests/` (e.g. `tests fixtures data`) to include them.
- Fresh `uv venv` inside the sandbox — no path leakage from the source checkout, which is the whole point.
- Handles Windows runners by branching `PY` to `.venv/Scripts/python.exe`.

### Suggested adoption pattern

A calling repo runs `wheel-smoke.yml` in parallel with `test.yml`; both must pass. It's also reasonable to make it a required status check only on releases, not every PR, if runtime cost is a concern.
