### PR TITLE
Enable Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  # Version updates for GitHub Actions used by the reusable workflows.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"


### PR DESCRIPTION
Part of umbrella issue #31 (context for the overall Node-runtime and stale-pin situation; see also the companion "bump actions to current" PR #30).

---

- Adds `.github/dependabot.yml` enabling weekly Dependabot updates for the GitHub Actions referenced across this repo's reusable workflows.

### Motivation

The reusables here depend on a handful of third-party actions (`actions/checkout`, `actions/setup-python`, `astral-sh/setup-uv`, `softprops/action-gh-release`, `EndBug/add-and-commit`, `mathieudutour/github-tag-action`, `TriPSs/conventional-changelog-action`, and others). When those actions publish updates — including security patches and bug fixes like the ones referenced in open issues on this repo — every downstream caller inherits whatever versions are pinned here. Without Dependabot, pins only move on manual bumps, which in practice lag.

Weekly cadence matches common practice. `commit-message.prefix: "chore(deps)"` with `include: "scope"` produces commits like `chore(deps): bump actions/checkout from 4 to 6`, lining up with the conventional-commits style used elsewhere.

### Further action required

You might need to change the repository settings to enable this.