### PR TITLE
Bump GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,9 +16,9 @@ jobs:
         python-version: [ '3.11', '3.12' ]
     steps: 
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Install UV - set python version to ${{ matrix.python-version }} 
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         python-version: ${{ matrix.python-version }} 
     - name: Lint with Ruff 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6
     - name: Install UV - set python version to ${{ matrix.python-version }} 
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: ${{ matrix.python-version }} 
     - name: Lint with Ruff 

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -16,7 +16,7 @@ jobs:
       UV_TOOL_DIR: C:\ProgramData\AIBS_MPE\uv_python
     steps:  
       - name: Install UV
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
       - name: Checkout code
         uses: actions/checkout@v6
       - name: Run makefile test

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -16,9 +16,9 @@ jobs:
       UV_TOOL_DIR: C:\ProgramData\AIBS_MPE\uv_python
     steps:  
       - name: Install UV
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run makefile test
         run: make test
       - name: Run makefile lint

--- a/.github/workflows/publish_devpi.yml
+++ b/.github/workflows/publish_devpi.yml
@@ -21,7 +21,7 @@ jobs:
       UV_TOOL_DIR: C:\ProgramData\AIBS_MPE\uv_python
     steps:
       - name: Install UV 
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
       - name: Build Project
         run: uv build
       - name: Publish Project to eng-tools devpi

--- a/.github/workflows/publish_devpi.yml
+++ b/.github/workflows/publish_devpi.yml
@@ -21,7 +21,7 @@ jobs:
       UV_TOOL_DIR: C:\ProgramData\AIBS_MPE\uv_python
     steps:
       - name: Install UV 
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
       - name: Build Project
         run: uv build
       - name: Publish Project to eng-tools devpi

--- a/.github/workflows/publish_executable.yml
+++ b/.github/workflows/publish_executable.yml
@@ -36,7 +36,7 @@ jobs:
       UV_TOOL_DIR: C:\ProgramData\AIBS_MPE\uv_python
     steps:
       - name: Install UV 
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
       - name: Echo extracted project info
         run: |
           echo "Project Name: ${{ needs.extract-info.outputs.project-name }}"
@@ -55,7 +55,7 @@ jobs:
       project-version: ${{ needs.build.outputs.project-version }}
     steps: 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             ${{ needs.build.outputs.project-name }}.zip

--- a/.github/workflows/publish_executable.yml
+++ b/.github/workflows/publish_executable.yml
@@ -36,7 +36,7 @@ jobs:
       UV_TOOL_DIR: C:\ProgramData\AIBS_MPE\uv_python
     steps:
       - name: Install UV 
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
       - name: Echo extracted project info
         run: |
           echo "Project Name: ${{ needs.extract-info.outputs.project-name }}"

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -32,7 +32,7 @@ jobs:
         working-directory: ./${{ inputs.working-directory }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         ref: ${{ inputs.default_branch }}
         fetch-depth: 0
@@ -72,7 +72,7 @@ jobs:
       id: output_version
       run: echo "new_version=${{ env.VERSION }}" >> "$GITHUB_OUTPUT"
     - name: Commit and Push version bump
-      uses: EndBug/add-and-commit@v9
+      uses: EndBug/add-and-commit@v10
       with:
         default_author: github_actions
         message: "ci: version bump [skip actions]"

--- a/.github/workflows/release-publish-docker-image.yml
+++ b/.github/workflows/release-publish-docker-image.yml
@@ -41,7 +41,7 @@ jobs:
         working-directory: ./${{ inputs.working-directory }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.default-branch }}
       - name: Set branch tag
@@ -56,15 +56,15 @@ jobs:
           echo "repo_owner=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
           echo "repo_name=$(echo '${{ inputs.image-name }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
       - name: Login to Github Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.repo-token }}
       - name: Build and push image to GitHub Container Registry
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           context: ./${{ inputs.working-directory }}
           push: true

--- a/.github/workflows/release-tag-and-publish-pipeline.yml
+++ b/.github/workflows/release-tag-and-publish-pipeline.yml
@@ -31,13 +31,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Fetch all history for tags
 
       - name: Conventional Changelog Action
         id: changelog
-        uses: TriPSs/conventional-changelog-action@v5
+        uses: TriPSs/conventional-changelog-action@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           skip-version-file: 'true'
@@ -95,7 +95,7 @@ jobs:
 
       - name: Commit and push version bump
         if: ${{ steps.changelog.outputs.skipped == 'false' }}
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@v10
         with:
           default_author: github_actions
           message: "ci: bump version to ${{ steps.changelog.outputs.version }} [skip ci]"
@@ -112,7 +112,7 @@ jobs:
 
       - name: Create GitHub Release
         if: ${{ steps.changelog.outputs.skipped == 'false' }}
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.changelog.outputs.tag }}
           name: Release ${{ steps.changelog.outputs.tag }}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -32,7 +32,7 @@ jobs:
         working-directory: ./${{ inputs.working-directory }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         ref: ${{ inputs.default_branch }}
         fetch-depth: 0

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -16,7 +16,7 @@ jobs:
       UV_TOOL_DIR: C:\ProgramData\AIBS_MPE\uv_python
     steps: 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with: 
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
@@ -29,11 +29,11 @@ jobs:
           pre_release_branches: dev
           # custom_release_rules: 'fix:patch,feat:minor,breaking:major' 
       - name: Install UV 
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
       - name: Update Version in pyproject.toml
         run: uvx --from=toml-cli toml set --toml-path=pyproject.toml project.version ${{ steps.tag_version.outputs.new_version }}
       - name: Commit and push pyproject.toml version bump
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@v10
         with:
           default_author: github_actions
           message: "ci: version bump"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -29,7 +29,7 @@ jobs:
           pre_release_branches: dev
           # custom_release_rules: 'fix:patch,feat:minor,breaking:major' 
       - name: Install UV 
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
       - name: Update Version in pyproject.toml
         run: uvx --from=toml-cli toml set --toml-path=pyproject.toml project.version ${{ steps.tag_version.outputs.new_version }}
       - name: Commit and push pyproject.toml version bump

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -21,9 +21,9 @@ jobs:
       run:
         working-directory: ./${{ inputs.working-directory }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6
     - name: Install UV - set python version to ${{ matrix.python-version }} 
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: ${{ matrix.python-version }} 
     - name: Unit test with PyTest  

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,9 @@ jobs:
         python-version: [ '3.11', '3.12' ]
     steps: 
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Install UV - set python version to ${{ matrix.python-version }} 
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         python-version: ${{ matrix.python-version }} 
     - name: Unit test with PyTest  

--- a/.github/workflows/type.yml
+++ b/.github/workflows/type.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6
     - name: Install UV - set python version to ${{ matrix.python-version }} 
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: ${{ matrix.python-version }} 
     - name: Type check with mypy 

--- a/.github/workflows/type.yml
+++ b/.github/workflows/type.yml
@@ -16,9 +16,9 @@ jobs:
         python-version: [ '3.11', '3.12' ]
     steps: 
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Install UV - set python version to ${{ matrix.python-version }} 
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         python-version: ${{ matrix.python-version }} 
     - name: Type check with mypy 

--- a/.github/workflows/util-update-badges.yml
+++ b/.github/workflows/util-update-badges.yml
@@ -30,13 +30,13 @@ jobs:
       run:
         working-directory: ./${{ inputs.working-directory }}
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         ref: ${{ inputs.default-branch }}
         fetch-depth: 0
         token: ${{ secrets.repo-token }}
     - name: Set up Python 3.10
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
     - name: Install dependencies
@@ -80,7 +80,7 @@ jobs:
     - name: Pull latest changes
       run: git pull origin ${{ inputs.default-branch }}
     - name: Commit changes
-      uses: EndBug/add-and-commit@v9
+      uses: EndBug/add-and-commit@v10
       with:
         default_author: github_actions
         message: "ci: update badges [skip actions]"


### PR DESCRIPTION
Part of umbrella issue #31 (context for the Node-runtime situation and the companion Dependabot PR).

## Why now

Four actions currently pinned in this repo run on **Node 16**, which GitHub has deprecated. Every invocation produces warnings; newer runners already hard-fail on some Node 16 actions.

| Workflow | Action | Pin | Node |
|---|---|---|---|
| `release-tag.yml` | `actions/checkout` | `@v3` | 16 |
| `release-publish-docker-image.yml` | `docker/setup-buildx-action` | `@v2` | 16 |
| `release-publish-docker-image.yml` | `docker/login-action` | `@v2` | 16 |
| `release-publish-docker-image.yml` | `docker/build-push-action` | `@v3` | 16 |

Seven more actions are pinned to **Node 20**, which is on GitHub's deprecation track with enforcement expected June 2026. Bumping them alongside the Node-16 fixes avoids doing this same review again six months from now.

## Bumps

| Action | From | To | Notes |
|---|---|---|---|
| `actions/checkout` | v3 / v4 / v5 | **v6** | Inputs used here (`ref`, `fetch-depth`, `token`) are stable across v3→v6 |
| `actions/setup-python` | v5 | **v6** | `python-version` input unchanged |
| `astral-sh/setup-uv` | v5 | **v7** | See note below on v7 vs v8 |
| `softprops/action-gh-release` | v1, v2 | **v3** | `tag_name` / `name` / `body` / `files` stable |
| `EndBug/add-and-commit` | v9 | **v10** | v10 is a dep-bump major in practice — no behavioral breaking changes per the compare-view diff |
| `TriPSs/conventional-changelog-action` | v5 | **v6** | v6's stated breaking change is `prerelease` semantics; this repo's caller doesn't use `prerelease` |
| `docker/setup-buildx-action` | v2 | **v4** | No inputs used in the caller |
| `docker/login-action` | v2 | **v4** | `registry` / `username` / `password` stable |
| `docker/build-push-action` | v3 | **v7** | v3→v4 enabled `provenance` attestations by default — fine for the ghcr.io target here |

30 call-sites across 13 workflow files. Diff is purely `@vX → @vY`.

## Not bumped

- `actions/github-script@v9` — already latest, Node 24.
- **`mathieudutour/github-tag-action@v6.2`** — already the latest upstream release, but still on Node 20 with no newer version published. When GitHub enforces Node 20 deprecation, `release-bump-version.yml` and `tag.yml` will fail. Needs a separate conversation (wait on upstream, or migrate to a different tag action — the latter overlaps with the commitizen-migration discussion in #22 / #26). Called out in #<umbrella>.

## Related

- Companion PR: enable Dependabot — #29
- Umbrella issue: #<umbrella>
