### PR TITLE
ci: add release-bump-version-uv.yml to enable uv version bump

### DIFF
--- a/.github/docs/Bump_Version_uv.md
+++ b/.github/docs/Bump_Version_uv.md
@@ -1,0 +1,54 @@
+# Bump And Tag (uv)
+
+**Name:** `Bump And Tag (uv)`
+
+**Workflow File:** `release-bump-version.yml`
+
+**Description:**
+
+This workflow automatically bumps the project version using semantic versioning, updates version references in the package's `pyproject.toml`, `uv.lock`, and `CITATION.cff` (if present), commits the changes, creates a Git tag with the new version, and pushes it to the repository. It is designed to be triggered via `workflow_call` and supports customizable default branches.
+
+It is assumed that the version is managed in the `pyproject.toml` file. The workflow will use `uv version` and `uv sync` to update the version in the `pyproject.toml` and `uv.lock` files.
+
+**Created By:** AIND Scientific Computing
+
+## Parameters
+
+**Inputs:**
+
+- `default_branch` (optional): Default branch name  
+  - default: `main`
+- `working-directory` (optional): The working directory to run the job in
+  - default: `.`
+
+**Secrets:**
+
+- `repo-token` (required): GitHub token with permissions to push commits and tags
+
+**Outputs:**
+
+- `new_version`: The new version string after the bump
+
+## Example
+
+**workflow.yml**
+```yml
+name: Bump And Tag
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  bump-and-tag:
+    uses: your-org/.github/.github/workflows/release-bump-version-uv.yml@main
+    with:
+      default_branch: main
+    secrets:
+      repo-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+**Results:**
+
+- Calculates the new version (default: patch bump), updates version in the package's `pyproject.toml`, `uv.lock`, and `CITATION.cff` (if present), commits the changes, creates a Git tag with the format `v{version}`, and pushes both the commit and tag to the repository.

--- a/.github/docs/Bump_Version_uv.md
+++ b/.github/docs/Bump_Version_uv.md
@@ -8,7 +8,7 @@
 
 This workflow automatically bumps the project version using semantic versioning, updates version references in the package's `pyproject.toml`, `uv.lock`, and `CITATION.cff` (if present), commits the changes, creates a Git tag with the new version, and pushes it to the repository. It is designed to be triggered via `workflow_call` and supports customizable default branches.
 
-It is assumed that the version is managed in the `pyproject.toml` file. The workflow will use `uv version` and `uv sync` to update the version in the `pyproject.toml` and `uv.lock` files.
+It is assumed that the version is managed in the `pyproject.toml` file. The workflow will use `uv version` and `uv lock` to update the version in the `pyproject.toml` and `uv.lock` files.
 
 **Created By:** AIND Scientific Computing
 

--- a/.github/workflows/release-bump-version-uv.yml
+++ b/.github/workflows/release-bump-version-uv.yml
@@ -1,0 +1,82 @@
+name: Bump And Tag (uv)
+
+on:
+  workflow_call:
+    outputs:
+      new_version:
+        description: 'The new version'
+        value: ${{ jobs.bump-and-tag.outputs.new_version }}
+    inputs:
+      default_branch:
+        description: 'Default branch name'
+        default: main
+        required: false
+        type: string
+      working-directory:
+        description: 'The working directory to run the job in'
+        required: false
+        type: string
+        default: '.'
+    secrets:
+      repo-token:
+        required: true
+
+jobs:
+  bump-and-tag:
+    name: Bump version and Tag
+    runs-on: ubuntu-latest
+    outputs:
+      new_version: ${{ steps.output_version.outputs.new_version }}
+    defaults:
+      run:
+        working-directory: ./${{ inputs.working-directory }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v5
+      with:
+        ref: ${{ inputs.default_branch }}
+        fetch-depth: 0
+        token: ${{ secrets.repo-token }}
+    - name: Compute new version number
+      id: tag_version
+      uses: mathieudutour/github-tag-action@v6.2
+      with:
+        github_token: ${{ secrets.repo-token }}
+        release_branches: ${{ inputs.default_branch }}
+        default_bump: patch
+        dry_run: true  # Perform dryrun first to calculate new version
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
+    - name: Set version variable
+      run: |
+        echo "VERSION=${{ steps.tag_version.outputs.new_version }}" >> "$GITHUB_ENV"
+    - name: Update pyproject.toml and uv.lock with new version
+      run: |
+        uv version "${{ env.VERSION }}"
+        uv sync
+    - name: Update version in CITATION.cff file
+      run: |
+        if [ -f CITATION.cff ]; then
+          sed -i --debug --expression='s/^version: .*/version: "v${{ env.VERSION }}"/' CITATION.cff
+          sed -i --debug --expression="s/^date-released: .*/date-released: $(date +%Y-%m-%d)/" CITATION.cff
+        fi
+    - name: Set files to commit
+      run: |
+        files_to_add="pyproject.toml uv.lock"
+        if [ -f CITATION.cff ]; then
+          files_to_add="$files_to_add CITATION.cff"
+        fi
+        echo "FILES_TO_ADD=$files_to_add" >> "$GITHUB_ENV"
+    - name: Set output
+      id: output_version
+      run: echo "new_version=${{ env.VERSION }}" >> "$GITHUB_OUTPUT"
+    - name: Commit and Push version bump
+      uses: EndBug/add-and-commit@v9
+      with:
+        default_author: github_actions
+        message: "ci: version bump [skip actions]"
+        add: ${{ env.FILES_TO_ADD }}
+    - name: Update tag
+      run: |
+        git tag "v${{ env.VERSION }}"
+        git push origin "v${{ env.VERSION }}"

--- a/.github/workflows/release-bump-version-uv.yml
+++ b/.github/workflows/release-bump-version-uv.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Update pyproject.toml and uv.lock with new version
       run: |
         uv version "${{ env.VERSION }}"
-        uv sync
+        uv lock
     - name: Update version in CITATION.cff file
       run: |
         if [ -f CITATION.cff ]; then


### PR DESCRIPTION
closes #32

The aind-library-template is being updated to use uv. Projects that use uv along with versions managed in the pyproject.toml file (instead of `__init__.py`) can use this new workflow to generate a new version, bump the version, and create a new GitHub tag.

This PR adds a new reusable workflow `release-bump-version-uv.yml` which is based on `release-bump-version.yml`, but uses `uv version` and `uv lock` to update the version.