### PR TITLE
fix release-uv

### DIFF
--- a/.github/workflows/release-bump-version-uv.yml
+++ b/.github/workflows/release-bump-version-uv.yml
@@ -75,6 +75,7 @@ jobs:
       with:
         default_author: github_actions
         message: "ci: version bump [skip actions]"
+        cwd: ${{ inputs.working-directory }}
         add: ${{ env.FILES_TO_ADD }}
     - name: Update tag
       run: |


### PR DESCRIPTION
Fix release uv workflow. The workflow fails when your pyproject.toml and uv.lock isn't in the root directory. 


The following only works for "run" steps and now "use" steps like add-and-commit. 
```
    defaults:
      run:
        working-directory: ./${{ inputs.working-directory }}
```

Need to use ``cwd`` in add-and-commit workflow for it to work properly. 