### PR TITLE
add the service account to the pipeline release yml

### DIFF
--- a/.github/workflows/release-tag-and-publish-pipeline.yml
+++ b/.github/workflows/release-tag-and-publish-pipeline.yml
@@ -15,6 +15,9 @@ on:
         required: false
         type: string
         default: ''
+    secrets:
+      SERVICE_TOKEN:
+        required: false
 
 jobs:
   version-bump:
@@ -34,6 +37,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Fetch all history for tags
+          token: ${{ secrets.SERVICE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Conventional Changelog Action
         id: changelog


### PR DESCRIPTION
## Root cause

The workflow pushes the version-bump commit and tag using the default
`GITHUB_TOKEN` (identity `github-actions[bot]`). **GitHub never lets the default
`GITHUB_TOKEN` bypass a ruleset** — by design, so workflows can't trivially
circumvent branch protection. Adding `github-actions[bot]` as a ruleset bypass
actor is accepted but inert, and the first-party GitHub Actions app is rejected as
a bypass actor (`422`). The only way a CI push can land on a PR-protected branch is
to push with a credential that **is** a bypass actor — i.e. a service-account PAT.

The library workflow (`tag_and_publish.yml`) already does this via `SERVICE_TOKEN`
(`svc-aindscicomp`); this pipeline workflow was the outlier still on `GITHUB_TOKEN`.

## Change

- Declare an optional `SERVICE_TOKEN` secret on the `workflow_call` interface.
- Use it as the `actions/checkout` `token`, so the persisted credentials used by
  the version-bump commit and tag pushes belong to the service account.
- **Backward compatible:** falls back to `GITHUB_TOKEN` when `SERVICE_TOKEN` is
  not provided (`${{ secrets.SERVICE_TOKEN || secrets.GITHUB_TOKEN }}`), preserving
  current behavior for repos without a PR-required ruleset.

## Required to take effect (per calling pipeline repo)

1. Provision a `SERVICE_TOKEN` secret = a PAT for `svc-aindscicomp` (already a
   `User` bypass actor on the standardized "Branch Protection" ruleset).
2. Pass it through from the caller `release.yml`:
   ```yaml
   jobs:
     release:
       uses: AllenNeuralDynamics/.github/.github/workflows/release-tag-and-publish-pipeline.yml@main
       secrets: inherit