### PR TITLE
Add SIPE workflows

### DIFF
--- a/.github/workflows/tag-release-build-sipe.yml
+++ b/.github/workflows/tag-release-build-sipe.yml
@@ -1,0 +1,210 @@
+# Reusable workflow: Tag and Publish
+#
+# Reads project name and version from pyproject.toml, creates a Git tag and
+# GitHub Release (skipped if the tag already exists), builds and tests an
+# executable, attaches artifacts to the release, and optionally calls the
+# SIPE gh-pull-agent API and deploys docs to GitHub Pages.
+#
+# Usage (caller workflow):
+#  
+#   on:
+#     push:
+#       branches:
+#         - main
+#         - dev
+#     workflow_dispatch:
+#
+#   jobs:
+#     tag-and-publish:
+#       uses: <org>/<repo>/.github/workflows/sipe-tag-build-publish.yml@<ref>
+#       with:
+#         auto_detect_artifacts_folder: dist   # optional, default: ''
+#         release_files: CHANGELOG.md          # optional, extra files to attach
+#         build_command: make exe              # optional, default: 'make exe'
+#         test_command: make test_exe          # optional, default: 'make test_exe'
+#         call_sipe_releases_api: true         # optional, default: true
+#         deploy_runner: eng-tools             # optional, default: 'eng-tools'
+#         api_base_url: http://...             # optional, default: SIPE endpoint
+#         build_docs: true                     # optional, default: true
+#         docs_build_command: make docs        # optional, default: 'make docs'
+#         docs_artifact_path: site             # optional, default: 'site'
+#       secrets:
+#         gh_token: ${{ secrets.YOUR_PAT }}    # optional, falls back to GITHUB_TOKEN
+#
+# Artifact detection (auto_detect_artifacts_folder):
+#   When set, every top-level item in that folder is included in the release.
+#   Folders are automatically zipped; files are attached as-is.
+#   Items listed in release_files are appended on top of the detected artifacts.
+
+# To use this docs method, set up your repo to use GitHub Pages with the "GitHub Actions" source
+
+name: Tag and Publish
+
+on:
+  workflow_call:
+    inputs:
+      sync_command:
+        description: 'Command to install dependencies and create environment'
+        required: false
+        type: string
+        default: 'uv sync'
+      build_command:
+        description: 'Command to build the executable'
+        required: false
+        type: string
+        default: 'make exe'
+      test_command:
+        description: 'Command to test the executable'
+        required: false
+        type: string
+        default: 'make test_exe'
+      auto_detect_artifacts_folder:
+        description: 'Folder to auto-detect artifacts for release'
+        required: false
+        type: string
+        default: 'dist'
+      release_files:
+        description: 'Newline-separated list of additional files to add to the release, alongside the auto-detected artifact.'
+        required: false
+        type: string
+        default: ''
+      call_sipe_releases_api: 
+        description: 'Whether to call the SIPE releases API after creating the release'
+        required: false
+        type: boolean
+        default: true
+      deploy_runner:
+        description: 'Runner label for the deployment job'
+        required: false
+        type: string
+        default: 'eng-tools'
+      api_base_url:
+        description: 'Base URL for the deployment API'
+        required: false
+        type: string
+        default: 'http://eng-tools/gh-pull-agent/api/v1beta/releases'
+      build_docs:
+        description: 'Whether to build and deploy documentation to GitHub Pages'
+        required: false
+        type: boolean
+        default: true
+      docs_build_command:
+        description: 'Command to build the documentation'
+        required: false
+        type: string
+        default: 'make docs'
+      docs_artifact_path:
+        description: 'Path to the built documentation artifact'
+        required: false
+        type: string
+        default: 'site'
+    secrets:
+      gh_token:
+        description: 'GitHub personal access token. Needed if you have private gh repo dependencies.'
+        required: false
+      
+jobs:
+  tag-release:
+    uses: ./.github/workflows/tag-release-sipe.yml
+    with:
+      sync_command: ${{ inputs.sync_command }}
+      build_docs: ${{ inputs.build_docs }}
+      docs_build_command: ${{ inputs.docs_build_command }}
+      docs_artifact_path: ${{ inputs.docs_artifact_path }}
+    secrets:
+      gh_token: ${{ secrets.gh_token }}
+
+  build_and_release:
+    needs: [tag-release]
+    if: needs.tag-release.outputs.tag_already_exists == 'false'
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: astral-sh/setup-uv@v5
+      with:
+        enable-cache: true
+        
+    - name: Register the personal access token
+      run: echo "${{ secrets.gh_token || github.token }}" | gh auth login --with-token
+    - name: Configure the Git credential helper
+      run: gh auth setup-git
+
+    - name: Build executable
+      run: ${{ inputs.build_command }}
+
+    - name: Test executable
+      timeout-minutes: 5
+      run: ${{ inputs.test_command }}
+
+    - name: Find artifacts for release
+      if: inputs.auto_detect_artifacts_folder
+      id: find_artifacts
+      run: |
+        # List every top-level item under the auto-detect folder
+        if (-not (Test-Path -Path "${{ inputs.auto_detect_artifacts_folder }}" -PathType Container)) {
+          Write-Output "auto_detect_artifacts_folder '${{ inputs.auto_detect_artifacts_folder }}' not found, skipping."
+          exit 0
+        }
+        $items = Get-ChildItem -Path "${{ inputs.auto_detect_artifacts_folder }}" |
+          ForEach-Object { $_.FullName }
+        $items | ForEach-Object { Write-Output "Found: $_" }
+        $delimiter = [System.Guid]::NewGuid().ToString()
+        Add-Content -Path $env:GITHUB_OUTPUT -Value "artifact_paths<<$delimiter"
+        $items | Add-Content -Path $env:GITHUB_OUTPUT
+        Add-Content -Path $env:GITHUB_OUTPUT -Value $delimiter
+
+    - name: Prepare release files
+      id: prepare_files
+      env:
+        RELEASE_FILES: ${{ inputs.release_files }}
+        FOUND_ARTIFACTS: ${{ steps.find_artifacts.outputs.artifact_paths }}
+      run: |
+        # Combine auto-detected artifacts with any explicitly provided release_files
+        # For each file: zip folders, pass files through as-is
+        $releaseFiles = @()
+        foreach ($file in (@($env:FOUND_ARTIFACTS, $env:RELEASE_FILES) -join "`n") -split '\r?\n' -ne '') {
+          if (Test-Path -Path $file -PathType Container) {
+            # Folder — zip its contents and substitute the zip path
+            $zipName = (Split-Path $file -Leaf) + ".zip"
+            Compress-Archive -Path "$file\*" -DestinationPath $zipName -Force
+            $releaseFiles += $zipName
+          } else {
+            # File — pass through as-is
+            $releaseFiles += $file
+          }
+        }
+        # Write the final file list as a multiline GITHUB_OUTPUT value
+        $delimiter = [System.Guid]::NewGuid().ToString()
+        Add-Content -Path $env:GITHUB_OUTPUT -Value "files<<$delimiter"
+        $releaseFiles | Add-Content -Path $env:GITHUB_OUTPUT
+        Add-Content -Path $env:GITHUB_OUTPUT -Value $delimiter
+
+    - name: Add artifacts to release
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: ${{ needs.tag-release.outputs.tag_name }}
+        fail_on_unmatched_files: true
+        files: ${{ steps.prepare_files.outputs.files }}
+
+  call-api:
+    if: ${{ inputs.call_sipe_releases_api }}
+    runs-on: ${{ inputs.deploy_runner }}
+    needs: [tag-release, build_and_release]
+    steps: 
+      - name: Trigger gh-pull-agent to pull latest release from this repo on eng-tools
+        run: |
+          $project_name = '${{ needs.tag-release.outputs.project_name_underscores }}'
+          $project_version = '${{ needs.tag-release.outputs.project_version }}'
+          $owner_name = '"${{ github.repository_owner }}"'
+          $repo_name = '"${{ github.event.repository.name }}"'
+          $tag_name = '"${{ needs.tag-release.outputs.tag_name }}"'
+          $json = @{
+            '"owner_name"' = $owner_name
+            '"repo_name"' = $repo_name
+            '"tag_name"' = $tag_name
+          } | ConvertTo-Json -Compress
+          & curl.exe -X PUT "${{ inputs.api_base_url }}/$project_name/$project_version" `
+            -H "accept: application/json" `
+            -H "Content-Type: application/json" `
+            -d $json
+          exit $LASTEXITCODE

--- a/.github/workflows/tag-release-sipe
+++ b/.github/workflows/tag-release-sipe
@@ -1,0 +1,179 @@
+# Reusable workflow: Tag and Release
+#
+# Reads project name and version from pyproject.toml, creates a Git tag and
+# GitHub Release and optionally deploys docs to GitHub Pages.
+#
+# Usage (caller workflow):
+#  
+#   on:
+#     push:
+#       branches:
+#         - main
+#         - dev
+#     workflow_dispatch:
+#
+#   jobs:
+#     tag-and-release:
+#       uses: <org>/<repo>/.github/workflows/tag-release.yml@<ref>
+#       with:
+#         sync_command: uv sync                # optional, default: 'uv sync'
+#         fail_if_tag_exists: false            # optional, default: false
+#         build_docs: true                     # optional, default: true
+#         docs_build_command: make docs        # optional, default: 'make docs'
+#         docs_artifact_path: site             # optional, default: 'site'
+#       secrets:
+#         gh_token: ${{ secrets.YOUR_PAT }}    # optional, falls back to GITHUB_TOKEN
+#
+# To use this docs method, set up your repo to use GitHub Pages with the "GitHub Actions" source
+
+
+name: Tag And Release
+
+on:
+  workflow_call:
+    inputs:
+      sync_command:
+        description: 'Command to install dependencies and create environment'
+        required: false
+        type: string
+        default: 'uv sync'
+      fail_if_tag_exists:
+        description: 'Fail the workflow if the tag already exists, instead of skipping'
+        required: false
+        type: boolean
+        default: false
+      build_docs:
+        description: 'Whether to build and deploy documentation to GitHub Pages'
+        required: false
+        type: boolean
+        default: true
+      docs_build_command:
+        description: 'Command to build the documentation'
+        required: false
+        type: string
+        default: 'uv run --group docs mkdocs build'
+      docs_artifact_path:
+        description: 'Path to the built documentation artifact'
+        required: false
+        type: string
+        default: 'site'
+    secrets:
+      gh_token:
+        description: 'GitHub personal access token. Needed if you have private gh repo dependencies.'
+        required: false
+    outputs:
+      project_name:
+        value: ${{ jobs.extract_info.outputs.project_name }}
+      project_version:
+        value: ${{ jobs.extract_info.outputs.project_version }}
+      project_name_underscores:
+        value: ${{ jobs.extract_info.outputs.project_name_underscores }}
+      tag_name:
+        value: ${{ jobs.extract_info.outputs.tag_name }}
+      tag_already_exists:
+        value: ${{ jobs.extract_info.outputs.tag_already_exists }}
+
+jobs: 
+  extract_info:
+    runs-on: windows-latest
+    outputs:
+      project_name: ${{ steps.get_info.outputs.PACKAGE_NAME }}
+      project_version: ${{ steps.get_info.outputs.PACKAGE_VERSION }}
+      project_name_underscores: ${{ steps.get_info.outputs.PACKAGE_NAME_UNDERSCORES }}
+      tag_name: v${{ steps.get_info.outputs.PACKAGE_VERSION }}
+      tag_already_exists: ${{ steps.check_existing_tag.outputs.exists }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: astral-sh/setup-uv@v5
+      with:
+        enable-cache: true
+
+    - name: Get package name and version
+      id: get_info
+      run: |
+        $version = uvx --from=toml-cli toml get --toml-path=pyproject.toml project.version
+        $package_name = uvx --from=toml-cli toml get --toml-path=pyproject.toml project.name
+        echo "PACKAGE_VERSION=$version" >> $env:GITHUB_OUTPUT
+        echo "PACKAGE_NAME=$package_name" >> $env:GITHUB_OUTPUT
+        echo "PACKAGE_NAME_UNDERSCORES=$package_name".Replace('-', '_') >> $env:GITHUB_OUTPUT
+        
+    - name: Check if tag exists
+      id: check_existing_tag
+      uses: mukunku/tag-exists-action@v1.6.0
+      with:
+        tag: v${{ steps.get_info.outputs.PACKAGE_VERSION }}
+
+
+  tag_and_release:
+    needs: extract_info
+    if: needs.extract_info.outputs.tag_already_exists == 'false' || inputs.fail_if_tag_exists
+    runs-on: windows-latest
+    steps:
+    - name: Fail if tag already exists
+      if: needs.extract_info.outputs.tag_already_exists == 'true'
+      run: |
+        Write-Error "Tag ${{ needs.extract_info.outputs.tag_name }} already exists."
+        exit 1
+    - uses: actions/checkout@v4
+    - uses: astral-sh/setup-uv@v5
+      with:
+        enable-cache: true
+
+    - name: Register the personal access token
+      run: echo "${{ secrets.gh_token || github.token }}" | gh auth login --with-token
+    - name: Configure the Git credential helper
+      run: gh auth setup-git
+
+    - name: Install dependencies
+      run: ${{ inputs.sync_command }}
+        
+    - name: Create Git tag
+      run: |
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+        git tag -a ${{ needs.extract_info.outputs.tag_name }} -m "${{ needs.extract_info.outputs.tag_name }}"
+        if ($LASTEXITCODE) { exit $LASTEXITCODE }
+        git push origin ${{ needs.extract_info.outputs.tag_name }}
+        if ($LASTEXITCODE) { exit $LASTEXITCODE }
+
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: ${{ needs.extract_info.outputs.tag_name }}
+        name: Release ${{ needs.extract_info.outputs.tag_name }}
+        generate_release_notes: true
+        prerelease: ${{ github.ref != 'refs/heads/main' }}
+
+  build-docs:
+    if: ${{ inputs.build_docs }}
+    needs: tag_and_release
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+      actions: write       # Necessary to cancel workflow executions
+      checks: write        # Necessary to write reports
+      pull-requests: write # Necessary to comment on PRs
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: astral-sh/setup-uv@v5
+      with:
+        enable-cache: true
+
+    - name: Build docs
+      run: ${{ inputs.docs_build_command }}
+
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: ${{ inputs.docs_artifact_path }}
+        
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4


### PR DESCRIPTION
tag-release-sipe: Reads project name and version from pyproject.toml, creates a Git tag and GitHub Release if tag doesn't already exist (option to fail) and optionally deploys docs to GitHub Pages.

tag-build-release-sipe: Does tag-release-sipe, but also builds artifacts like an exe and attaches to the release, and has a step on internal runner to call sipe's internal tool to grab releases and store them on-prem. That last step can only be used on "internal" repos, as public repos won't let you call internal runners.